### PR TITLE
php8.3

### DIFF
--- a/drupal-composer/php8.3/Dockerfile
+++ b/drupal-composer/php8.3/Dockerfile
@@ -1,0 +1,12 @@
+FROM composer:2.6.6
+
+LABEL maintainer="jason@ciandt.com"
+
+RUN apk upgrade --update && apk add \
+      libjpeg-turbo-dev \
+      libpng-dev \
+  	libzip-dev \
+	zip \
+      icu-dev \
+	&& docker-php-ext-configure gd --with-jpeg \
+	&& docker-php-ext-install gd pdo pdo_mysql zip intl


### PR DESCRIPTION
项目升级到8.3
添加编译8.3版本的compose

使用ciandtchina/composer-drupal:php8.1编译时 jenkins报以下错误
  Problem 1
    - chi-teck/drupal-code-generator is locked to version 4.0.0 and an update of this package was not requested.
    - chi-teck/drupal-code-generator 4.0.0 requires php >=8.3.0 -> your php version (8.1.4) does not satisfy that requirement.