### PR TITLE
Add PHP 8.4 Drupal Docker images

### DIFF
--- a/drupal-composer/README.md
+++ b/drupal-composer/README.md
@@ -2,6 +2,7 @@
 Extend support for Drupal build based on official composer docker image
 
 ## Supported tags and respective `Dockerfile` links
+-	[`8.4` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-images/blob/master/drupal-composer/php8.4/Dockerfile)
 -	[`alpine` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-drupal-composer/blob/master/alpine/Dockerfile)
 
 ## The purpose of this container image

--- a/drupal-composer/php8.4/Dockerfile
+++ b/drupal-composer/php8.4/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.4-cli-alpine
+
+LABEL maintainer="jason@ciandt.com"
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+RUN apk upgrade --update && apk add --no-cache \
+      icu-dev \
+      libjpeg-turbo-dev \
+      libpng-dev \
+      libzip-dev \
+      zip \
+    && docker-php-ext-configure gd --with-jpeg \
+    && docker-php-ext-install gd pdo pdo_mysql zip intl

--- a/drupal-web/README.md
+++ b/drupal-web/README.md
@@ -2,6 +2,7 @@
 Standalone Apache/PHP container with necessary packages and extensions installed for Drupal
 
 ## Supported tags and respective `Dockerfile` links
+-	[`8.4-fpm-apache` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-images/blob/master/drupal-web/php8.4-fpm-apache/Dockerfile)
 -	[`7.4`, `latest` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-drupal-web/blob/master/php7.4/Dockerfile)
 -	[`7.3` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-drupal-web/blob/master/php7.3/Dockerfile)
 -	[`7.2` (*Dockerfile*)](https://github.com/ciandt-china-dev/docker-drupal-web/blob/master/php7.2/Dockerfile)

--- a/drupal-web/php8.4-fpm-apache/Dockerfile
+++ b/drupal-web/php8.4-fpm-apache/Dockerfile
@@ -1,0 +1,64 @@
+FROM php:8.4-fpm-bookworm
+
+ENV APACHE_CONFDIR=/etc/apache2 \
+    APACHE_ENVVARS=/etc/apache2/envvars \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        apache2 \
+        ca-certificates \
+        default-mysql-client \
+        exim4 \
+        git \
+        imagemagick \
+        libavif-dev \
+        libbz2-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libmagickwand-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libpq-dev \
+        libsasl2-dev \
+        libwebp-dev \
+        libxml2-dev \
+        libzip-dev \
+        rsyslog \
+        unzip \
+        zlib1g-dev; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-avif; \
+    docker-php-ext-install -j"$(nproc)" \
+        bz2 \
+        gd \
+        intl \
+        opcache \
+        pdo_mysql \
+        pdo_pgsql \
+        soap \
+        sockets \
+        zip; \
+    yes '' | pecl install apcu memcached imagick; \
+    docker-php-ext-enable apcu memcached imagick; \
+    a2dismod mpm_prefork; \
+    a2enmod mpm_event proxy proxy_fcgi proxy_http rewrite; \
+    sed -ri 's!^([[:space:]]*)DocumentRoot .+!\1DocumentRoot /var/www/html/docroot!' /etc/apache2/sites-available/000-default.conf; \
+    sed -ri 's!^user = .+!user = docker!; s!^group = .+!group = docker!' /usr/local/etc/php-fpm.d/www.conf; \
+    groupadd -g 1001 docker; \
+    useradd -u 1000 -g docker -m -s /bin/sh docker; \
+    ln -sf /usr/bin/mysqldump /usr/bin/mariadb-dump || true; \
+    mkdir -p /var/www/html; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY php.ini /usr/local/etc/php/conf.d/zz-nshr-local.ini
+COPY docker-php.conf /etc/apache2/conf-enabled/docker-php.conf
+COPY apache2-foreground /usr/local/bin/apache2-foreground
+COPY start.sh /start.sh
+
+RUN chmod +x /usr/local/bin/apache2-foreground /start.sh
+
+WORKDIR /var/www/html
+EXPOSE 80
+CMD ["/start.sh"]

--- a/drupal-web/php8.4-fpm-apache/apache2-foreground
+++ b/drupal-web/php8.4-fpm-apache/apache2-foreground
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+: "${APACHE_CONFDIR:=/etc/apache2}"
+: "${APACHE_ENVVARS:=$APACHE_CONFDIR/envvars}"
+if [ -f "$APACHE_ENVVARS" ]; then
+    . "$APACHE_ENVVARS"
+fi
+
+: "${APACHE_RUN_DIR:=/var/run/apache2}"
+: "${APACHE_PID_FILE:=$APACHE_RUN_DIR/apache2.pid}"
+rm -f "$APACHE_PID_FILE"
+
+for e in "${!APACHE_@}"; do
+    if [[ "$e" == *_DIR ]] && [[ "${!e}" == /* ]]; then
+        dir="${!e}"
+        while [ "$dir" != "$(dirname "$dir")" ]; do
+            dir="$(dirname "$dir")"
+            if [ -d "$dir" ]; then
+                break
+            fi
+            abs_dir="$(readlink -f "$dir" 2>/dev/null || :)"
+            if [ -n "$abs_dir" ]; then
+                mkdir -p "$abs_dir"
+            fi
+        done
+
+        mkdir -p "${!e}"
+    fi
+done
+
+exec apache2 -DFOREGROUND "$@"

--- a/drupal-web/php8.4-fpm-apache/docker-php.conf
+++ b/drupal-web/php8.4-fpm-apache/docker-php.conf
@@ -1,0 +1,11 @@
+<FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+</FilesMatch>
+
+DirectoryIndex disabled
+DirectoryIndex index.php index.html
+
+<Directory /var/www/>
+    Options -Indexes
+    AllowOverride All
+</Directory>

--- a/drupal-web/php8.4-fpm-apache/php.ini
+++ b/drupal-web/php8.4-fpm-apache/php.ini
@@ -1,0 +1,18 @@
+; Local PHP 8.4 settings for the Nestle China HR portal.
+
+opcache.enable=1
+opcache.enable_cli=1
+opcache.interned_strings_buffer=8
+opcache.memory_consumption=128
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+opcache.save_comments=1
+
+upload_max_filesize=50M
+post_max_size=50M
+memory_limit=512M
+expose_php=off
+display_errors=Off
+display_startup_errors=Off
+log_errors=On
+error_reporting=E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED

--- a/drupal-web/php8.4-fpm-apache/start.sh
+++ b/drupal-web/php8.4-fpm-apache/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ "$(id -u docker)" != "${CURRENT_USER_UID:-1000}" ]; then
+    usermod -u "${CURRENT_USER_UID:-1000}" docker
+fi
+
+if [ "$(id -g docker)" != "${CURRENT_USER_GID:-1001}" ]; then
+    groupmod -g "${CURRENT_USER_GID:-1001}" docker
+fi
+
+if [ ! -e /usr/bin/mariadb-dump ]; then
+    ln -s /usr/bin/mysqldump /usr/bin/mariadb-dump
+fi
+nohup rsyslogd -n -f /etc/rsyslog.conf >/var/log/rsyslogd.log 2>&1 &
+update-ca-certificates
+service exim4 start || true
+php-fpm -D
+exec apache2-foreground


### PR DESCRIPTION
## Summary

- Add Drupal web PHP 8.4 FPM Apache Docker image
- Add Drupal Composer PHP 8.4 Docker image
- Update drupal-web and drupal-composer README supported tags

## Verification

- Built `drupal-web:php8.4-fpm-apache`
- Built `drupal-composer:php8.4`
- Verified PHP 8.4 and Composer are available in the Composer image
- Verified required PHP extensions are loaded: `gd`, `intl`, `PDO`, `pdo_mysql`, `zip`
